### PR TITLE
Adding parameter Browser

### DIFF
--- a/testng.xml
+++ b/testng.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="Suite">
   <test thread-count="5" name="Test2">   
+    <parameter name="Browser" value="Chrome"/>
     <classes>
       <class name="mavenforjenkins.UITest"/>      
     </classes>


### PR DESCRIPTION
To avoid build failure where parameter browser is required but not provided in testng.xml.  Error message for the above issue:
Parameter 'Browser' is required by @Test on method startBrowser but has not been marked @Optional or defined